### PR TITLE
Remove corrupted duplicate div tag

### DIFF
--- a/pages/_includes/navbar.html
+++ b/pages/_includes/navbar.html
@@ -10,7 +10,6 @@
      <img height="50" alt="visit the hl7 website" width="42" src="assets/images/hl7-logo.png"/>
     </a>
    </div>
-   <div id="hl7-nav"><a id="hl7-logo" no-external="true"</div>
   </div>
   <div class="container">  <!-- container -->
  </div></div>  <!-- /segment-header -->


### PR DESCRIPTION
Removed a div tag that contained an incomplete anchor tag within it.  It turns out the whole div was a duplicate anyway.  Probably a copy/paste error.